### PR TITLE
Fix the expected output of JSON.stringify for Proxy objects

### DIFF
--- a/Escargot/regression-tests/issue-235.js
+++ b/Escargot/regression-tests/issue-235.js
@@ -21,4 +21,4 @@ a.constructor = {
   }
 }
 
-assert(JSON.stringify(a.concat()) == "{}")
+assert(JSON.stringify(a.concat()) == "[]")


### PR DESCRIPTION
Signed-off-by: Robert Fancsik <frobert@inf.u-szeged.hu>