### PR TITLE
Fix finalizer tc to clearly invoke a finalizer

### DIFF
--- a/Escargot/new-es/finalization-registry-object.js
+++ b/Escargot/new-es/finalization-registry-object.js
@@ -99,6 +99,7 @@ function test4() {
   for (var i = 0; i < 1000; i++) {
     wr.register(target, "too many registers");
   }
+  target = null;
 }
 
 test4();
@@ -120,6 +121,7 @@ function test5() {
     wr.register(target, "too many registers", target);
   }
   wr.unregister(target);
+  target = null;
 }
 
 test5();


### PR DESCRIPTION
* local variable mignt be remained in the stack even after callee execution
* clearly allocate `null` value to this local variable to make finalizer called certainly

Signed-off-by: HyukWoo Park <hyukwoo.park@samsung.com>